### PR TITLE
Display raw HTML as well as plain text

### DIFF
--- a/main.go
+++ b/main.go
@@ -121,8 +121,10 @@ func getMail(latestMsg publicMsg, cookies []*http.Cookie) error {
 
 	fmt.Println("\nFrom   :", mailMessage.Data.From)
 	fmt.Println("Subject:", mailMessage.Data.Subject)
-	fmt.Println()
+	fmt.Println("Plain text:")
 	fmt.Println(mailMessage.Data.Parts[0].Body)
+	fmt.Println("HTML:")
+	fmt.Println(mailMessage.Data.Parts[1].Body)
 	return nil
 }
 


### PR DESCRIPTION
Attempt to address #3.

In some cases, links may be not shown in the text, but are available in
the HTML form of the email.

Not entirely sure whether Mailinator's JSON will always contain this
part, e.g. if an email is plain text only.