### PR TITLE
Fix retrieval of data after recent site update

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ type mailboxDetails struct {
 }
 
 func getMailboxDetails(localPart string) (mailboxDetails, error) {
-	webInboxURL := "https://www.mailinator.com/api/webinbox2?x=0&public_to=" + localPart
+	webInboxURL := "https://www.mailinator.com/fetch_inbox?zone=public&to=" + localPart
 	fmt.Println("Retrieving URL:", webInboxURL)
 
 	mbxDetails := mailboxDetails{}
@@ -80,7 +80,7 @@ func getMailboxDetails(localPart string) (mailboxDetails, error) {
 func getCookies(latestMsg publicMsg) ([]*http.Cookie, error) {
 	// This request is for nothing but getting required cookies.
 	// Otherwise, the subsequent request fails.
-	inboxURL := "https://www.mailinator.com/inbox2.jsp?public_to=" + latestMsg.To
+	inboxURL := "https://www.mailinator.com/inbox2.jsp?to=" + latestMsg.To
 	fmt.Println("Retrieving URL:", inboxURL)
 
 	inboxResp, err := http.Get(inboxURL)
@@ -94,7 +94,7 @@ func getCookies(latestMsg publicMsg) ([]*http.Cookie, error) {
 }
 
 func getMail(latestMsg publicMsg, cookies []*http.Cookie) error {
-	msgURL := "https://www.mailinator.com/fetchmail?msgid=" + latestMsg.ID + "&zone=public"
+	msgURL := "https://www.mailinator.com/fetch_email?zone=public&msgid=" + latestMsg.ID
 	fmt.Println("Retrieving URL:", msgURL)
 	req, err := http.NewRequest("GET", msgURL, nil)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -47,7 +47,9 @@ type mail struct {
 		Parts   []struct {
 			Body string `json:"body"`
 		} `json:"parts"`
-		From string `json:"from"`
+		Headers struct {
+			From string `json:"from"`
+		} `json:"headers"`
 	} `json:"data"`
 }
 
@@ -57,7 +59,7 @@ type publicMsg struct {
 }
 
 type mailboxDetails struct {
-	PublicMsgs []publicMsg `json:"public_msgs"`
+	PublicMsgs []publicMsg `json:"messages"`
 }
 
 func getMailboxDetails(localPart string) (mailboxDetails, error) {
@@ -119,7 +121,7 @@ func getMail(latestMsg publicMsg, cookies []*http.Cookie) error {
 		return err
 	}
 
-	fmt.Println("\nFrom   :", mailMessage.Data.From)
+	fmt.Println("\nFrom   :", mailMessage.Data.Headers.From)
 	fmt.Println("Subject:", mailMessage.Data.Subject)
 	fmt.Println("Plain text:")
 	fmt.Println(mailMessage.Data.Parts[0].Body)


### PR DESCRIPTION
Mailinator changed their site (URLs, query strings and JSON structure).

Unfortunately, this broke go-mailin8.

But now it's fixed :)