### PR TITLE
Switch service from Mailinator to nada

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,22 @@
 # go-mailin8
 
-Display the latest mail from a temporary Mailinator email address, at
-the command line.
+Display the latest mail from a temporary [nada](https://getnada.com)
+email address, at the command line.
 
 Useful for getting confirmation emails for throwaway purposes, or for
 testing.
 
-This is a version of a [bash script I
+## History (or "why is this called go-mailin8?")
+
+Originally, this used Mailinator's service to retrieve email; however,
+they rebuilt their site and this became a WebSocket powered application,
+making it more difficult to work with.
+
+This was a version of a [bash script I
 made](https://gist.github.com/StevenMaude/914e9187c09027866fe88958798acb7e)
 that uses [jq](https://stedolan.github.io/jq/). However, this Go version
-requires no other dependencies.
+requires no other dependencies, and now uses a different disposable
+email service.
 
 ## Build
 
@@ -17,20 +24,11 @@ requires no other dependencies.
 
 ## Usage
 
-1. Send, or get an email sent to a Mailinator email address of your
-   choosing.
-2. Note the local-part (the part before @, e.g.
-   `somefakeemail1234@mailinator.com`).
-3. Run `go-mailin8 <local-part of email address>`
-
-## Notes
-
-NB: you may get unpredictable results from the server if you run this
-too often in a short time. See TODO.
+1. Send, or get an email sent to a [nada](https://getnada.com) email
+   address of your choosing.
+2. Run `go-mailin8 <email address>`
 
 ## TODO:
 
-* Consider introducing slight pauses between requests to try and
-  improve reliability.
 * Possibly consider selecting other than latest message (though outside
   of my original use case).

--- a/main.go
+++ b/main.go
@@ -97,7 +97,7 @@ func getInbox(address string) (inbox, error) {
 func main() {
 	// TODO: consider allow to retrieve more than one message.
 	if len(os.Args) != 2 {
-		fmt.Println("Usage: mailin8 <local-part>")
+		fmt.Println("Usage: mailin8 <address>")
 		os.Exit(1)
 	}
 

--- a/main.go
+++ b/main.go
@@ -14,38 +14,12 @@ type mail struct {
 	Text    string `json:"text"`
 }
 
-type publicMsg struct {
-	ID string `json:"id"`
-	To string `json:"to"`
-}
-
-type mailboxDetails struct {
-	PublicMsgs []publicMsg `json:"messages"`
-}
-
 type msg struct {
 	UID string `json:"uid"`
 }
 
 type inbox struct {
 	Msgs []msg `json:"msgs"`
-}
-
-func getMailboxDetails(localPart string) (mailboxDetails, error) {
-	webInboxURL := "https://www.mailinator.com/fetch_inbox?zone=public&to=" + localPart
-	fmt.Println("Retrieving URL:", webInboxURL)
-
-	mbxDetails := mailboxDetails{}
-	resp, err := http.Get(webInboxURL)
-	if err != nil {
-		return mbxDetails, err
-	}
-
-	defer resp.Body.Close()
-	err = json.NewDecoder(resp.Body).Decode(&mbxDetails)
-	// No need for error check here as we return mbxDetails and err whether
-	// we have an error or not.
-	return mbxDetails, err
 }
 
 func getMail(latestMsg msg) error {

--- a/main.go
+++ b/main.go
@@ -53,22 +53,6 @@ func getMailboxDetails(localPart string) (mailboxDetails, error) {
 	return mbxDetails, err
 }
 
-func getCookies(latestMsg publicMsg) ([]*http.Cookie, error) {
-	// This request is for nothing but getting required cookies.
-	// Otherwise, the subsequent request fails.
-	inboxURL := "https://www.mailinator.com/inbox2.jsp?to=" + latestMsg.To
-	fmt.Println("Retrieving URL:", inboxURL)
-
-	inboxResp, err := http.Get(inboxURL)
-	defer inboxResp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	cookies := inboxResp.Cookies()
-	return cookies, err
-}
-
 func getMail(latestMsg publicMsg, cookies []*http.Cookie) error {
 	msgURL := "https://www.mailinator.com/fetch_email?zone=public&msgid=" + latestMsg.ID
 	fmt.Println("Retrieving URL:", msgURL)
@@ -149,12 +133,6 @@ func main() {
 
 	// latestMsg := mbxDetails.PublicMsgs[numberMsgs-1]
 
-	//cookies, err := getCookies(latestMsg)
-	//if err != nil {
-	//	fmt.Println("failed to get cookies:", err)
-	//	os.Exit(1)
-	//}
-	//
 	//	err = getMail(latestMsg, cookies)
 	//	if err != nil {
 	//		fmt.Println("failed to get mail:", err)


### PR DESCRIPTION
Mailinator became difficult to work with, so switch to using
[nada](https://getnada.com) instead.

Implement text and HTML email collection.

Fixes #10.