### PR TITLE
Remove `gomod` check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
* We're not using any dependencies here.
* Dependabot doesn't seem to pick up transitive dependencies.